### PR TITLE
nikhil/semantic-nerf-configurability

### DIFF
--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -39,7 +39,7 @@ class Semantics:
     """filenames to load semantic data"""
     classes: List[str]
     """class labels for data"""
-    colors: List[str]
+    colors: List[List[int]]
     """color mapping for classes"""
     mask_classes: List[str] = field(default_factory=lambda: [])
     """classes to mask out from training for all modalities"""

--- a/nerfstudio/data/dataparsers/base_dataparser.py
+++ b/nerfstudio/data/dataparsers/base_dataparser.py
@@ -39,7 +39,7 @@ class Semantics:
     """filenames to load semantic data"""
     classes: List[str]
     """class labels for data"""
-    colors: torch.Tensor
+    colors: List[str]
     """color mapping for classes"""
     mask_classes: List[str] = field(default_factory=lambda: [])
     """classes to mask out from training for all modalities"""

--- a/nerfstudio/fields/nerfacto_field.py
+++ b/nerfstudio/fields/nerfacto_field.py
@@ -18,6 +18,7 @@ Field for compound nerf model, adds scene contraction and image embeddings to in
 
 
 from typing import Dict, Optional, Tuple
+from typing_extensions import Literal
 
 import numpy as np
 import torch
@@ -109,6 +110,7 @@ class TCNNNerfactoField(Field):
         use_transient_embedding: bool = False,
         use_semantics: bool = False,
         num_semantic_classes: int = 100,
+        pass_semantic_gradients: bool = False,
         use_pred_normals: bool = False,
         use_average_appearance_embedding: bool = False,
         spatial_distortion: Optional[SpatialDistortion] = None,
@@ -126,6 +128,7 @@ class TCNNNerfactoField(Field):
         self.use_transient_embedding = use_transient_embedding
         self.use_semantics = use_semantics
         self.use_pred_normals = use_pred_normals
+        self.pass_semantic_gradients = pass_semantic_gradients
 
         base_res = 16
         features_per_level = 2
@@ -291,13 +294,10 @@ class TCNNNerfactoField(Field):
 
         # semantics
         if self.use_semantics:
-            density_embedding_copy = density_embedding.clone().detach()
-            semantics_input = torch.cat(
-                [
-                    density_embedding_copy.view(-1, self.geo_feat_dim),
-                ],
-                dim=-1,
-            )
+            semantics_input = density_embedding.view(-1, self.geo_feat_dim)
+            if not self.pass_semantic_gradients:
+                semantics_input = semantics_input.detach()
+            
             x = self.mlp_semantics(semantics_input).view(*outputs_shape, -1).to(directions)
             outputs[FieldHeadNames.SEMANTICS] = self.field_head_semantics(x)
 

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -76,6 +76,7 @@ class SemanticNerfWModel(Model):
         assert "semantics" in metadata.keys() and isinstance(metadata["semantics"], Semantics)
         self.semantics = metadata["semantics"]
         super().__init__(config=config, **kwargs)
+        self.colormap = torch.tensor(self.semantics.colors).to(self.device)
 
     def populate_modules(self):
         """Set the fields and modules."""
@@ -213,7 +214,7 @@ class SemanticNerfWModel(Model):
 
         # semantics colormaps
         semantic_labels = torch.argmax(torch.nn.functional.softmax(outputs["semantics"], dim=-1), dim=-1)
-        outputs["semantics_colormap"] = self.semantics.colors[semantic_labels]
+        outputs["semantics_colormap"] = self.colormap[semantic_labels]
 
         return outputs
 
@@ -287,7 +288,7 @@ class SemanticNerfWModel(Model):
 
         # semantics
         semantic_labels = torch.argmax(torch.nn.functional.softmax(outputs["semantics"], dim=-1), dim=-1)
-        images_dict["semantics_colormap"] = self.semantics.colors[semantic_labels]
+        images_dict["semantics_colormap"] = self.colormap[semantic_labels]
 
         # valid mask
         images_dict["mask"] = batch["mask"].repeat(1, 1, 3)

--- a/nerfstudio/models/semantic_nerfw.py
+++ b/nerfstudio/models/semantic_nerfw.py
@@ -60,8 +60,8 @@ class SemanticNerfWModelConfig(NerfactoModelConfig):
 
     _target: Type = field(default_factory=lambda: SemanticNerfWModel)
     use_transient_embedding: bool = False
-    semantic_loss_weight: float = 0.01
-    pass_semantic_gradients: bool = True
+    semantic_loss_weight: float = 1.0
+    pass_semantic_gradients: bool = False
     """Whether to use transient embedding."""
 
 


### PR DESCRIPTION
Fixes an issue currently with the semantic nerf vis, where currently all dataparsers pass in colours as a list of tuples, whereas the typing was enforced to be a tensor. Changes the type of colors in Semantics class to match that of classes, and convert to tensor within semantic nerf before indexing.

Currently the nerfacto model  does not pass any gradients from the seg head into any weights used for rgb rendering, from local experimentation I found that passing gradients through to these parameters improves the segmentation performance significantly, while only causing a very minor regression in the rgb metrics ( from 27.2 to 27.1 PSNR). Hence, adding this is a configrable option during training. Due to this - scaling segmentation loss also becomes more important and hence exposing this as an additional hyper-parameter as well 